### PR TITLE
Remove unexpected trailing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "webpack-dashboard -- webpack-dev-server --inline",
     "build": "webpack --progress --colors -p",
     "build:dev": "webpack --progress --colors",
-    "lint": "eslint src",
+    "lint": "eslint src"
   },
   "author": "Phillip Raffnsøe <phillip@praffn.dk>",
   "license": "MIT",


### PR DESCRIPTION
Yarn (probablz npm too) throws an error when parsing `package.json` if a trailing comma is present in line 14. This PR removes the trailing comma.